### PR TITLE
TECH Add metrics in blocked process detection and ajust log level

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,11 +1,11 @@
-[![CircleCI](https://circleci.com/gh/transcovo/chpr-blocked.svg?style=shield)](https://circleci.com/gh/transcovo/chpr-blocked)
+[![CircleCI](https://circleci.com/gh/transcovo/chpr-blocked.svg?style=shield&circle-token=34f2510e960a3185bf5a47ec89961f6fe63817f4)](https://circleci.com/gh/transcovo/chpr-blocked)
 [![codecov](https://codecov.io/gh/transcovo/chpr-blocked/branch/master/graph/badge.svg)](https://codecov.io/gh/transcovo/chpr-blocked)
 
-chpr-blocked is a tiny utility to monitor event loop blocking, inspired from tj/blocked,
+chpr-blocked is a tiny utility to monitor event loop blocking, inspired from [tj/blocked](https://github.com/tj/node-blocked),
 but configurable with environment variables.
 
-When the event loop is blocked for more than a set threshold (defaults to 100ms), an error log
-is emitted, using chpr-logger.
+When the event loop is blocked for more than a set threshold (defaults to 100ms), an info log
+is emitted, using chpr-logger and metrics sent (increment + timing).
 
 There is a "warmup delay" (defaults to 2000ms), because it's ok to use a lot of CPU in
 at the statup of the node app (e.g. to require most of the app code).
@@ -30,4 +30,5 @@ The configuration is done with environment variables.
 |---|---|---|
 | BLOCKED_DELAY | The tolerated warmup time after requiring chpr-blocked, milliseconds  | 2000 |
 | BLOCKED_THERSHOLD | (deprecated ) see BLOCKED_THRESHOLD, here for retro-compatibility | 100 |
-| BLOCKED_THRESHOLD | The threshold above which an error will be logged, once the warmup delay is over | 100 |
+| BLOCKED_THRESHOLD | The threshold above which an error
+| BLOCKED_LOGGER_LEVEL | The logger level to apply on a blocked process | error

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ class BlockedMonitor {
     if (typeof logger[this.loggerLevel] !== 'function') {
       throw new Error('Invalid logger level definition');
     }
+    this.logFunction = logger[this.loggerLevel].bind(logger);
 
     if (this.running) {
       throw new Error('Invalid state: already running');
@@ -58,7 +59,7 @@ class BlockedMonitor {
         if (blockedTime > this.threshold) {
           metrics.increment(`blocked`);
           metrics.timing(`blocked.duration`, blockedTime);
-          logger[this.loggerLevel]({ blockedTime, serviceName },
+          this.logFunction({ blockedTime, serviceName },
             '[chpr-blocked] Process blocked for an excessive amount of time');
         }
         startTime = process.hrtime();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const metrics = require('chpr-metrics');
 const logger = require('chpr-logger');
 
 /**
@@ -28,6 +29,10 @@ class BlockedMonitor {
     const deprecatedTypoThreshold = getIntFromEnv(process.env, 'BLOCKED_THERSHOLD', 100);
     // for retro-compatibility:
     this.threshold = getIntFromEnv(process.env, 'BLOCKED_THRESHOLD', deprecatedTypoThreshold);
+    this.loggerLevel = process.env.BLOCKED_LOGGER_LEVEL || 'error';
+    if (typeof logger[this.loggerLevel] !== 'function') {
+      throw new Error('Invalid logger level definition');
+    }
 
     if (this.running) {
       throw new Error('Invalid state: already running');
@@ -51,7 +56,9 @@ class BlockedMonitor {
         const blockedTime = ms - checkInterval;
 
         if (blockedTime > this.threshold) {
-          logger.error({ blockedTime, serviceName },
+          metrics.increment(`blocked`);
+          metrics.timing(`blocked.duration`, blockedTime);
+          logger[this.loggerLevel]({ blockedTime, serviceName },
             '[chpr-blocked] Process blocked for an excessive amount of time');
         }
         startTime = process.hrtime();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-blocked",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Inspired from tj/blocked, but configurable with environment variables",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,8 @@
   "author": "Chauffeur Privé",
   "license": "ISC",
   "dependencies": {
-    "chpr-logger": "2.4.1"
+    "chpr-logger": "2.4.1",
+    "chpr-metrics": "1.1.0"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
This PR is adding the following features:
- Send metrics about blocked process detection counts
- Send metrics about blocked process duration
- Allow to adjust the logger level on a blocked process detection