### PR TITLE
TECH Unref interval to avoid processes from exiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class BlockedMonitor {
             '[chpr-blocked] Process blocked for an excessive amount of time');
         }
         startTime = process.hrtime();
-      }, checkInterval);
+      }, checkInterval).unref();
     }, this.delay).unref();
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chpr-blocked",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Inspired from tj/blocked, but configurable with environment variables",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Not sure how, but in some cases the interval is still running after the service has been stopped, must be some kind of race condition with `this.running`.
I didn't bother investigating why as this can only happen in the microservices tests where we are doing a lot of start-stop.